### PR TITLE
fix: hyphenated permissions regex

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ### What's Changed
 
-* fix: double pipe issue  by @iqbalhasandev in https://github.com/DevWizardHQ/laravel-react-permissions/pull/23
+- fix: double pipe issue by @iqbalhasandev in
+  https://github.com/DevWizardHQ/laravel-react-permissions/pull/23
 
 **Full Changelog**: https://github.com/DevWizardHQ/laravel-react-permissions/compare/v1.1.3...v1.1.4
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project
 adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## v1.1.5 - 2025-01-27
+
+### Fixed
+
+- **Critical Fix**: Fixed `ReferenceError: all is not defined` error when using hyphenated permission names in expressions
+- Fixed regex word boundary issue that prevented proper matching of permissions containing hyphens (e.g., `view-all`, `user-profile.edit`)
+- Permission expressions like `visitor.request.view-all||visitor.request.view-department` now work correctly
+
+### Added
+
+- Comprehensive test suite for hyphenated permissions covering various edge cases
+- Support for complex nested expressions with hyphenated permission names
+- Better handling of mixed permission types (hyphenated and non-hyphenated)
+
+### Technical Details
+
+- Updated `evaluatePermissionExpression` function to use word boundaries only for non-hyphenated permissions
+- Hyphenated permissions now use simple regex matching instead of word boundaries
+- Maintains backward compatibility with existing non-hyphenated permissions
+
 ## v1.1.4 - 2025-09-25
 
 ### What's Changed

--- a/__tests__/hyphenated-permissions.test.tsx
+++ b/__tests__/hyphenated-permissions.test.tsx
@@ -1,0 +1,171 @@
+import { renderHook } from '@testing-library/react';
+import { usePermissions } from '../hooks/use-permissions';
+
+// Mock @inertiajs/react
+jest.mock('@inertiajs/react', () => ({
+  usePage: () => ({
+    props: {
+      auth: {
+        user: {
+          permissions: global.mockUserPermissions || []
+        }
+      }
+    }
+  })
+}));
+
+const mockPageProps = (permissions: string[]) => {
+  global.mockUserPermissions = permissions;
+};
+
+describe('Hyphenated Permissions', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should handle hyphenated permissions in OR expressions', () => {
+    mockPageProps(['visitor.request.view-all', 'visitor.request.view-department']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    // Test the original failing expression
+    const expression = 'visitor.request.view-all||visitor.request.view-department||visitor.request.view-own';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should handle hyphenated permissions in AND expressions', () => {
+    mockPageProps(['user-profile.edit', 'api-access.read']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = 'user-profile.edit&&api-access.read';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should handle mixed hyphenated and non-hyphenated permissions', () => {
+    mockPageProps(['users.create', 'user-profile.edit', 'api-access.read']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    // Test OR with mixed types
+    const orExpression = 'users.create||user-profile.edit||api-access.read';
+    expect(result.current.hasPermission(orExpression)).toBe(true);
+
+    // Test AND with mixed types
+    const andExpression = 'users.create&&user-profile.edit&&api-access.read';
+    expect(result.current.hasPermission(andExpression)).toBe(true);
+  });
+
+  it('should handle complex nested expressions with hyphens', () => {
+    mockPageProps(['admin.access', 'user-profile.edit', 'system-config.update']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = '(admin.access||user-profile.edit)&&system-config.update';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should handle multiple hyphens in permission names', () => {
+    mockPageProps(['api-v2-endpoint.read', 'user-profile-settings.edit']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = 'api-v2-endpoint.read||user-profile-settings.edit';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should handle wildcards with hyphenated permissions', () => {
+    mockPageProps(['user-profile.edit', 'user-profile.delete', 'admin.access']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    // Test wildcard with hyphenated permissions
+    const wildcardExpression = 'user-profile.*';
+    expect(result.current.hasPermission(wildcardExpression)).toBe(true);
+
+    // Test wildcard with AND
+    const wildcardAndExpression = 'user-profile.*&&admin.access';
+    expect(result.current.hasPermission(wildcardAndExpression)).toBe(true);
+  });
+
+  it('should handle permissions with numbers and hyphens', () => {
+    mockPageProps(['api-v2-endpoint-2024.read', 'user-profile-v1.edit']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = 'api-v2-endpoint-2024.read||user-profile-v1.edit';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should handle mixed case hyphenated permissions', () => {
+    mockPageProps(['API-V2-Endpoint.Read', 'User-Profile-Settings.Edit']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = 'API-V2-Endpoint.Read||User-Profile-Settings.Edit';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should return false when user has no hyphenated permissions', () => {
+    mockPageProps([]);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = 'visitor.request.view-all||visitor.request.view-department';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(false);
+  });
+
+  it('should handle very long hyphenated permission names', () => {
+    mockPageProps(['very-long-permission-name-with-many-hyphens.and-more-hyphens']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    const expression = 'very-long-permission-name-with-many-hyphens.and-more-hyphens||short.permission';
+    const hasPermission = result.current.hasPermission(expression);
+
+    expect(hasPermission).toBe(true);
+  });
+
+  it('should not break with edge cases like consecutive hyphens', () => {
+    mockPageProps(['normal.permission']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    // These should not cause errors, even if they're invalid permission names
+    const expression1 = 'api--v2--endpoint.read||normal.permission';
+    const expression2 = 'invalid.permission-||normal.permission';
+    const expression3 = '-invalid.permission||normal.permission';
+
+    expect(result.current.hasPermission(expression1)).toBe(true);
+    expect(result.current.hasPermission(expression2)).toBe(true);
+    expect(result.current.hasPermission(expression3)).toBe(true);
+  });
+
+  it('should work with the Can component for hyphenated permissions', () => {
+    mockPageProps(['visitor.request.view-all']);
+
+    const { result } = renderHook(() => usePermissions());
+
+    // Test that the expression validation works
+    const expression = 'visitor.request.view-all||visitor.request.view-department';
+    const isValid = result.current.isValidExpression(expression);
+    const checkResult = result.current.checkExpression(expression);
+
+    expect(isValid).toBe(true);
+    expect(checkResult).toBe(true);
+  });
+});

--- a/hooks/use-permissions.tsx
+++ b/hooks/use-permissions.tsx
@@ -152,12 +152,18 @@ export function usePermissions(permissions?: string[]) {
           hasPermissionResult.toString()
         );
       } else {
-        // For normal permissions, use word boundaries
+        // For normal permissions, escape special regex characters
         const escapedPermission = permission.replace(
           /[.*+?^${}()|[\]\\]/g,
           '\\$&'
         );
-        const permissionRegex = new RegExp(`\\b${escapedPermission}\\b`, 'g');
+        
+        // Use word boundaries only if the permission doesn't contain hyphens
+        // because \b doesn't work with hyphens (they're considered word separators)
+        const permissionRegex = permission.includes('-')
+          ? new RegExp(escapedPermission, 'g')
+          : new RegExp(`\\b${escapedPermission}\\b`, 'g');
+        
         evaluatedExpression = evaluatedExpression.replace(
           permissionRegex,
           hasPermissionResult.toString()

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@devwizard/laravel-react-permissions",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "description": "🔐 Modern, Laravel-inspired permissions system for React/Inertia.js with advanced pattern matching, boolean expressions, and zero dependencies. Features wildcard patterns, custom permissions, and full TypeScript support.",
   "main": "dist/index.js",


### PR DESCRIPTION
This pull request addresses a critical bug in the permissions system related to hyphenated permission names, and introduces robust support and testing for complex permission expressions. The main focus is on ensuring that permissions containing hyphens (such as `view-all` or `user-profile.edit`) are properly matched and evaluated in boolean expressions, improving reliability and backward compatibility.

### Bug Fixes and Permission Matching

* Fixed a `ReferenceError: all is not defined` error and a regex word boundary issue that prevented proper matching of hyphenated permission names in permission expressions. Hyphenated permissions now use simple regex matching instead of word boundaries, resolving previous failures with expressions like `visitor.request.view-all||visitor.request.view-department`. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R33) [[2]](diffhunk://#diff-82cec9863d64411e9441a1ffe4c66ee4969b2a69763cbb8a500cd2699e5c00a6L155-R166)

### Testing Improvements

* Added a comprehensive test suite in `__tests__/hyphenated-permissions.test.tsx` to cover various edge cases involving hyphenated permissions, including OR/AND expressions, wildcards, mixed types, nested expressions, numbers, mixed case, long names, consecutive hyphens, and integration with the `Can` component.

### Technical Enhancements

* Updated the `evaluatePermissionExpression` logic in `hooks/use-permissions.tsx` to use word boundaries only for non-hyphenated permissions, ensuring correct matching for all permission formats and maintaining backward compatibility.
* Improved handling of mixed permission types (hyphenated and non-hyphenated) in expressions, supporting complex nested logic and wildcards. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R33) [[2]](diffhunk://#diff-4e7d82622ff20c2099acf2ba3d57c4c3647a013109292b80ae2155c4e748ac07R1-R171)

### Version and Documentation Updates

* Bumped the package version to `v1.1.5` in `package.json` and documented all notable changes in `CHANGELOG.md`. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L3-R3) [[2]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR8-R33)