### PR TITLE
fix: enable code quality workflow on pull requests

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -17,7 +17,7 @@ on:
     branches: [main, develop]
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
   quality-check:
@@ -27,9 +27,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
-          token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Setup Node.js
         uses: actions/setup-node@v6
@@ -40,16 +37,36 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Auto-fix formatting on push to main/develop (not on PRs)
-      - name: Format code
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
-        run: npx prettier --write .
+      - name: Check formatting
+        run: npm run format:check
 
       - name: Run ESLint
         run: npm run lint
 
+  auto-format:
+    name: Auto Format
+    if: github.event_name == 'push'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v6
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Format code
+        run: npm run format
+
       - name: Commit formatting changes
-        if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || github.ref == 'refs/heads/develop')
         uses: stefanzweifel/git-auto-commit-action@v7
         with:
           commit_message: 'style: fix code formatting [skip ci]'

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -13,8 +13,8 @@ on:
       - '.github/workflows/code-quality.yml'
       - 'tsconfig.json'
       - 'package.json'
-  # pull_request:
-  #   branches: [main, develop]
+  pull_request:
+    branches: [main, develop]
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary
- Uncomment the `pull_request` trigger in `code-quality.yml` so ESLint and format checks run on every PR
- The auto-format and auto-commit steps are already gated on `push` events only, so they won't attempt to commit on PRs

## Test plan
- [ ] Verify the Code Quality workflow appears as a check on this PR
- [ ] Verify ESLint passes